### PR TITLE
Way of installation

### DIFF
--- a/ARPACK_ARmake.inc.patch
+++ b/ARPACK_ARmake.inc.patch
@@ -5,7 +5,7 @@
  # %--------------------------------------%
  #
 -home = $(HOME)/ARPACK
-+home = $(HOME)/build_calculix/ARPACK
++home = $(HOME_BUILD)/ARPACK
  #
  #  %--------------------------------------%
  #  | The platform identifier to suffix to |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 # calculix_build
-Makefiles to build SPOOLES, ARPACK and CalculiX. The scripts automatically pull the software from internet, builds the software and installs it locally. The script must be run in ~/build_calculix (hard codes in the ARPACK patch) and will install in ~/calculix. The installation is started with 
 
-sh install
+Makefiles to build SPOOLES, ARPACK and CalculiX. The scripts automatically pull the software from internet, builds the software and installs it locally. 
+
+The script can be run anywhere after downloading:
+
+git clone https://github.com/luvres/calculix_build.git
+
+
+And will install in ~/calculix. The installation is started with
+
+./install

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Makefiles to build SPOOLES, ARPACK and CalculiX. The scripts automatically pull 
 The script can be run anywhere after downloading:
 
 git clone https://github.com/luvres/calculix_build.git
-
+cd calculix_build/
 
 And will install in ~/calculix. The installation is started with
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Makefiles to build SPOOLES, ARPACK and CalculiX. The scripts automatically pull 
 The script can be run anywhere after downloading:
 
 git clone https://github.com/luvres/calculix_build.git
+
 cd calculix_build/
+
 
 And will install in ~/calculix. The installation is started with
 

--- a/install
+++ b/install
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # You must run this in ~/build_calculix (hard coded in the ARPACK patch)
 # You will need gcc-fortran, cpio, freeglut, glu
 
@@ -9,6 +11,7 @@ export LDFLAGS="-L$PROGSDIR/lib"
 export CPPFLAGS="-I$PROGSDIR/include"
 export MY_LIB=$PROGSDIR/lib
 export MY_INCLUDE=$PROGSDIR/include
+export HOME_BUILD=$PWD
 
 mkdir -p $PROGSDIR
 mkdir -p $PROGSDIR/bin
@@ -17,7 +20,7 @@ mkdir -p $PROGSDIR/doc
 mkdir -p $PROGSDIR/include
  
 # Spooles as solver for CCX
-wget http://www.netlib.org/linalg/spooles/spooles.2.2.tgz
+wget -c --tries=1000000 http://www.netlib.org/linalg/spooles/spooles.2.2.tgz
 mkdir SPOOLES.2.2
 cp spooles.2.2.tgz SPOOLES.2.2
 cd SPOOLES.2.2
@@ -40,8 +43,8 @@ rm spooles.2.2.tgz
 
 # Install ARPACK to support CalculiX
 echo 'Building ARPACK'
-wget http://www.caam.rice.edu/software/ARPACK/SRC/arpack96.tar.gz
-wget http://www.caam.rice.edu/software/ARPACK/SRC/patch.tar.gz
+wget -c --tries=1000000 http://www.caam.rice.edu/software/ARPACK/SRC/arpack96.tar.gz
+wget -c --tries=1000000 http://www.caam.rice.edu/software/ARPACK/SRC/patch.tar.gz
 tar xzf arpack96.tar.gz
 tar xzf patch.tar.gz
 cd ARPACK
@@ -56,8 +59,8 @@ rm patch.tar.gz
 
 # CGX from CalculiX
 echo 'Installing CGX'
-wget http://www.dhondt.de/cgx_2.10.all.tar.bz2
-wget http://www.dhondt.de/cgx_2.10.pdf
+wget -c --tries=1000000 http://www.dhondt.de/cgx_2.10.all.tar.bz2
+wget -c --tries=1000000 http://www.dhondt.de/cgx_2.10.pdf
 tar xjf cgx_2.10.all.tar.bz2
 cd CalculiX/cgx_2.10/src
 make > ../../../cgx_make.txt 2> ../../../cgx_error.txt
@@ -70,8 +73,8 @@ rm cgx_2.10.pdf
 
 # CCX 2.10 with pardiso and spooles
 echo 'Installing CCX 2.10'
-wget http://www.dhondt.de/ccx_2.10.pdf
-wget http://www.dhondt.de/ccx_2.10.src.tar.bz2
+wget -c --tries=1000000 http://www.dhondt.de/ccx_2.10.pdf
+wget -c --tries=1000000 http://www.dhondt.de/ccx_2.10.src.tar.bz2
 tar xjf ccx_2.10.src.tar.bz2
 cd CalculiX/ccx_2.10
 cd src


### PR DESCRIPTION
Excellent script installation of CalculiX! It really is not a simple installation.

I was struggling to find your script.

There is a detail to be seen in its already excellent script and got some change suggestions I made for my use.

1.) Path "calculix_build" when git clone is named "build_calculix" in ARPACK_ARmake.inc.patch. To turn should point the name and create correct name:

cd $ HOME
git clone https://github.com/robhuls/calculix_build.git build_calculix
build_calculix cd /

2.) Tip to build anywhere and solve the previous question (were the changes I made)
sed -i '12s / ^ / export HOME_BUILD = $ PWD \ n /' install
sed -i 's / $ (HOME) \ / build_calculix / $ (HOME_BUILD) /' ARPACK_ARmake.inc.patch

3.) Tip for connection failures. When I setup my internet was terrible.
sed -i 's / wget / wget -c --tries = 1000000 /' install
